### PR TITLE
Put priority on AJAX calls so RBP initializes properly

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -117,7 +117,7 @@ class WooCommerce_Role_Based_Price {
             }
 		}
         
-	}
+}
     
     /**
      * Inits loaded Class
@@ -129,13 +129,13 @@ class WooCommerce_Role_Based_Price {
 		self::$settings = new WooCommerce_Role_Based_Price_Settings_Framework;
         self::$shortcode_handler = new WooCommerce_Role_Based_Price_Shortcode_Handler;
         
-		if(wc_rbp_is_request('admin')){
-            self::$admin = new WooCommerce_Role_Based_Price_Admin;
-        } else {
+        if(wc_rbp_is_request('frontend')){
             self::$frontend = new WooCommerce_Role_Based_Price_Product_Pricing;
+        } else if(wc_rbp_is_request('admin')){
+            self::$admin = new WooCommerce_Role_Based_Price_Admin;
         }
 		
-		do_action('wc_rbp_init');
+	do_action('wc_rbp_init');
     }
     
 	# Returns Plugin's Functions Instance


### PR DESCRIPTION
Without this commit, any AJAX calls result in the RBP plugin not
initializing. This causes huge problems, especially if you do not
have a default, non role based price.
One example of a problem would be the check for the cart session.
It checks to make sure the cart is still valid on each request, and
it uses the price to make sure the item is purchasable. In the case
that an AJAX request is made, we need the frontend plugin loaded
so that is_price will return proper prices and not see all the
items as non purchaseable.